### PR TITLE
fix: add value to the referenceTypeId column while exporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ branches:
 notifications:
   email: false
 node_js:
-- '6'
 - '8'
 before_script:
 - npm prune

--- a/tests/unit/product-type-export.spec.js
+++ b/tests/unit/product-type-export.spec.js
@@ -15,8 +15,10 @@ const options = {
   sphereClientConfig: {
     config: {
       project_key: PROJECT_KEY,
-      client_id: '*********',
-      client_secret: '*********',
+      client_id: process.env.CI === true ?
+        process.env.SPHERE_CLIENT_ID : '*********',
+      client_secret: process.env.CI === true ?
+        process.env.SPHERE_CLIENT_SECRET : '*********',
     },
     rest: {
       config: {},


### PR DESCRIPTION
#### Fix: ProductType export - Missing referenceTypeId attribute value

1) referenceTypeId attribute column value is awlays empty when exporting product type and their attributes. It is because we modify the **key** for  accesing **referenceTypeId**  using regex and uses the changed **key** to get the value of **reference typeId** from the attribute object.

https://jira.commercetools.com/browse/SUPPORT-12117

2) Fixed integration test cases CI environment variables. After moving this package to commercetools, all the env variables are lost from the travis-ci so added them and modified the code base to consume those.

Fix: #43 